### PR TITLE
Fix url for plone-devstart.py download

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ development environment.
 
 All you need is the single script, ``plone-devstart.py``::
 
-    $ curl -O https://github.com/optilude/plone-devstart/raw/master/plone-devstart.py
+    $ curl -O https://raw.github.com/plone/plone-devstart/master/plone-devstart.py
 
 You run it with::
 


### PR DESCRIPTION
Instead of pointing to Martin's repository, point to the plone one.
