### PR TITLE
while unzipping, skip the initial path element

### DIFF
--- a/plone-devstart.py
+++ b/plone-devstart.py
@@ -411,7 +411,9 @@ def create_buildout(directory, plone_version, version_config, options):
     zf = zipfile.ZipFile(skeleton_file)
 
     for name in zf.namelist():
-        target_name = os.path.join(directory, name)
+        target_name = os.path.join(directory, name[name.index('/') + 1:])
+        if not target_name:
+            continue
         target_directory = os.path.dirname(target_name)
 
         if not os.path.exists(target_directory):


### PR DESCRIPTION
The skeleton zip files include paths starting with, e.g., plone-4.2/. These were getting unzipped verbatim, so that the buildout.cfg was inside a plone-4.2 directory instead of at the root of the environment. This chops off the initial path element to fix that.

Related: #5
